### PR TITLE
Fixed main menu FadeIn/FadeOut buttons glitch.

### DIFF
--- a/src/mainMenuScene.js
+++ b/src/mainMenuScene.js
@@ -137,7 +137,7 @@ class MainMenuScene {
             // this is the first time through this action handler for this button press sequence
             console.log("ACIVATE - " + this.selectedItemIndex);
             const selectedItem = this.selectedItem;
-            if (selectedItem) {
+            if (selectedItem && selectedItem.isEnabled) {
                 
                 selectedItem.onPointerClickObservable.notifyObservers();
             }

--- a/src/mainMenuScene.js
+++ b/src/mainMenuScene.js
@@ -42,6 +42,7 @@ class MainMenuScene {
     onHighScoreActionObservable = new Observable();
     highScoreDialog;
     isTopMost = true;
+    buttons = [];
 
     get scene() {
         return this._scene;
@@ -246,6 +247,7 @@ class MainMenuScene {
         };
         const playButton = createMenuItem(pbOpts);
         this._menuGrid.addControl(playButton, this._menuGrid.children.length, 1);
+        this.buttons.push(playButton);
 
         const highScoreOpts = {
             name: "btHighScores",
@@ -260,6 +262,7 @@ class MainMenuScene {
         }
         const highScoreButton = createMenuItem(highScoreOpts);
         this._menuGrid.addControl(highScoreButton, this._menuGrid.children.length, 1);
+        this.buttons.push(highScoreButton);
 
         const ebOpts = {
             name: "btExit",
@@ -275,7 +278,7 @@ class MainMenuScene {
         }
         const exitButton = createMenuItem(ebOpts);
         this._menuGrid.addControl(exitButton, this._menuGrid.children.length, 1);
-
+        this.buttons.push(exitButton);
     }
 
     _createSelectorIcon() {
@@ -301,20 +304,28 @@ class MainMenuScene {
     }
 
     _onMenuEnter(duration) {
-        let fadeIn = 0;
         const fadeTime = duration || 1500;
         this._menuContainer.isVisible = true;
         this._menuContainer.alpha = 0;
+
+        // To prevent clicking on buttons during transition.
+        this.buttons.forEach((btn) => {
+            btn.isEnabled = false;
+            btn.alpha = 0;
+        });
+
         const timer = setAndStartTimer({
             timeout: fadeTime,
             contextObservable: this._scene.onBeforeRenderObservable,
             onTick: (d) => {                
                 const currAmt = Scalar.SmoothStep(0, 1, d.completeRate);
                 this._menuContainer.alpha = currAmt;
+                this.buttons.forEach((btn) => btn.alpha = currAmt);
             },
             onEnded: () => {
                 this.selectedItemIndex = 0;
                 this._menuContainer.alpha = 1.0;
+                this.buttons.forEach((btn) => btn.isEnabled = true);
             }
         });
         return timer;
@@ -324,7 +335,8 @@ class MainMenuScene {
         let fadeOut = 0;
         const fadeTime = duration || 1500;
 
-        this._menuContainer.isVisible = true;
+        // To prevent clicking on buttons during transition.
+        this.buttons.forEach((btn) => btn.isEnabled = false);
 
         const timer = setAndStartTimer({
             timeout: fadeTime,
@@ -334,7 +346,7 @@ class MainMenuScene {
                 fadeOut += dT;
                 const currAmt = Scalar.SmoothStep(1, 0, fadeOut / fadeTime);
                 this._menuContainer.alpha = currAmt;
-
+                this.buttons.forEach((btn) => btn.alpha = currAmt);
             },
             onEnded: () => {
                 this._menuContainer.alpha = 0;

--- a/src/mainMenuScene.js
+++ b/src/mainMenuScene.js
@@ -42,10 +42,13 @@ class MainMenuScene {
     onHighScoreActionObservable = new Observable();
     highScoreDialog;
     isTopMost = true;
-    buttons = [];
 
     get scene() {
         return this._scene;
+    }
+
+    get menuItems() {
+        return this._menuGrid.children.filter((item) => item instanceof Button);
     }
 
     get selectedItem() {
@@ -175,6 +178,7 @@ class MainMenuScene {
         menuContainer.cornerRadius = 13;
 
         this._guiMenu.addControl(menuContainer);
+        menuContainer.renderToIntermediateTexture = true;
         this._menuContainer = menuContainer;
 
         const menuBg = new Image("menuBg", menuBackground);
@@ -247,7 +251,6 @@ class MainMenuScene {
         };
         const playButton = createMenuItem(pbOpts);
         this._menuGrid.addControl(playButton, this._menuGrid.children.length, 1);
-        this.buttons.push(playButton);
 
         const highScoreOpts = {
             name: "btHighScores",
@@ -262,7 +265,6 @@ class MainMenuScene {
         }
         const highScoreButton = createMenuItem(highScoreOpts);
         this._menuGrid.addControl(highScoreButton, this._menuGrid.children.length, 1);
-        this.buttons.push(highScoreButton);
 
         const ebOpts = {
             name: "btExit",
@@ -278,7 +280,6 @@ class MainMenuScene {
         }
         const exitButton = createMenuItem(ebOpts);
         this._menuGrid.addControl(exitButton, this._menuGrid.children.length, 1);
-        this.buttons.push(exitButton);
     }
 
     _createSelectorIcon() {
@@ -309,10 +310,7 @@ class MainMenuScene {
         this._menuContainer.alpha = 0;
 
         // To prevent clicking on buttons during transition.
-        this.buttons.forEach((btn) => {
-            btn.isEnabled = false;
-            btn.alpha = 0;
-        });
+        this.menuItems.forEach((btn) => btn.isEnabled = false);
 
         const timer = setAndStartTimer({
             timeout: fadeTime,
@@ -320,12 +318,11 @@ class MainMenuScene {
             onTick: (d) => {                
                 const currAmt = Scalar.SmoothStep(0, 1, d.completeRate);
                 this._menuContainer.alpha = currAmt;
-                this.buttons.forEach((btn) => btn.alpha = currAmt);
             },
             onEnded: () => {
                 this.selectedItemIndex = 0;
                 this._menuContainer.alpha = 1.0;
-                this.buttons.forEach((btn) => btn.isEnabled = true);
+                this.menuItems.forEach((btn) => btn.isEnabled = true);
             }
         });
         return timer;
@@ -336,7 +333,7 @@ class MainMenuScene {
         const fadeTime = duration || 1500;
 
         // To prevent clicking on buttons during transition.
-        this.buttons.forEach((btn) => btn.isEnabled = false);
+        this.menuItems.forEach((btn) => btn.isEnabled = false);
 
         const timer = setAndStartTimer({
             timeout: fadeTime,
@@ -346,7 +343,6 @@ class MainMenuScene {
                 fadeOut += dT;
                 const currAmt = Scalar.SmoothStep(1, 0, fadeOut / fadeTime);
                 this._menuContainer.alpha = currAmt;
-                this.buttons.forEach((btn) => btn.alpha = currAmt);
             },
             onEnded: () => {
                 this._menuContainer.alpha = 0;


### PR DESCRIPTION
On develop branch FadeIn/FadeOut works a little bit better, so I just fixed the button alpha property glitch. I also disable buttons during transition, to prevent clicking on them in order to avoid potential glitches.
On the modern BabylonJS versions disabling the buttons draws them in a grayscale. We can try to find a way to suppress this behavior, but honestly, I don't think it looks bad. It explicitly says that the menu is in transition, so user needs to keep hands away.