### PR TITLE
Fix orbital circumference calculation

### DIFF
--- a/src/astroFactory.js
+++ b/src/astroFactory.js
@@ -47,7 +47,7 @@ class AstroFactory {
         planet.orbitOptions.period = period;
         planet.orbitOptions.orbitalVel = v;
         planet.orbitOptions.angularVel = w;
-        planet.orbitOptions.orbitalCircum = Math.pow(Math.PI * opts.posRadius, 2);
+        planet.orbitOptions.orbitalCircum = Scalar.TwoPi * opts.posRadius;
         planet.preRenderObsv = scene.onBeforeRenderObservable.add(() => {
             planet.position.x = opts.posRadius * Math.sin(angPos);
             planet.position.z = opts.posRadius * Math.cos(angPos);


### PR DESCRIPTION
The original code was caclulating the orbital circumference as the area spanned by a circle that has the planet's orbital radius, while it should be the length of the circle perimeter.