### PR TITLE
Fixed the rotating of the cargo in local space

### DIFF
--- a/src/route-planning/spaceTruckerPlanningScreen.js
+++ b/src/route-planning/spaceTruckerPlanningScreen.js
@@ -115,7 +115,7 @@ class SpaceTruckerPlanningScreen {
 
         this.scene = new Scene(engine);
         this.scene.onNewMeshAddedObservable.add(mesh => mesh.layerMask = PLANNING_SCREEN_LAYER_MASK);
-        
+
 
         this.config = config;
         const { blurParameter, environmentTexture, IBLIntensity, lightIntensity, skyboxScale } = config.environment;
@@ -308,25 +308,25 @@ class SpaceTruckerPlanningScreen {
 
     MOVE_LEFT(state) {
         if (this.gameState === PLANNING_STATE.ReadyToLaunch) {
-            this.cargo.mesh.rotate(Axis.Y, -this.launchRotationSpeed, Space.World);
+            this.cargo.mesh.rotate(Axis.Y, -this.launchRotationSpeed, Space.LOCAL);
         }
     }
 
     MOVE_RIGHT(state) {
         if (this.gameState === PLANNING_STATE.ReadyToLaunch) {
-            this.cargo.mesh.rotate(Axis.Y, this.launchRotationSpeed, Space.World);
+            this.cargo.mesh.rotate(Axis.Y, this.launchRotationSpeed, Space.LOCAL);
         }
     }
 
     MOVE_UP(state) {
         if (this.gameState === PLANNING_STATE.ReadyToLaunch) {
-            this.cargo.mesh.rotate(Axis.X, -this.launchRotationSpeed, Space.World);
+            this.cargo.mesh.rotate(Axis.X, -this.launchRotationSpeed, Space.LOCAL);
         }
     }
 
     MOVE_DOWN(state) {
         if (this.gameState === PLANNING_STATE.ReadyToLaunch) {
-            this.cargo.mesh.rotate(Axis.X, this.launchRotationSpeed, Space.World);
+            this.cargo.mesh.rotate(Axis.X, this.launchRotationSpeed, Space.LOCAL);
         }
     }
 


### PR DESCRIPTION
Hi!

This may be another typo. `Space.World` is not defined in `Space` module(`Space.WORLD` is the correct spelling), when this undefined value is passed to the `rotate` function, the latter will check and make it behaves as same as `Space.LOCAL`, and that's why the cargo's rotation-gizmo rotates as we expected.

Here's the src of `rotate`
```javascript
if (!space || space === Space.LOCAL) {
    rotationQuaternion = Quaternion.RotationAxisToRef(axis, amount, TransformNode._RotationAxisCache);
    this.rotationQuaternion.multiplyToRef(rotationQuaternion, this.rotationQuaternion);
}
```
